### PR TITLE
Add userconf support to Raspbian

### DIFF
--- a/partitions/Raspbian/partition_setup.sh
+++ b/partitions/Raspbian/partition_setup.sh
@@ -26,6 +26,14 @@ if [ -z $restore ]; then
     cp /mnt/ssh.txt /tmp/1/
   fi
 
+  if [ -f /mnt/userconf ]; then
+    cp /mnt/userconf /tmp/1/
+  fi
+
+  if [ -f /mnt/userconf.txt ]; then
+    cp /mnt/userconf.txt /tmp/1/
+  fi
+
   if [ -f /settings/wpa_supplicant.conf ]; then
     cp /settings/wpa_supplicant.conf /tmp/1/
   fi


### PR DESCRIPTION
Newer versions of Raspberry OS enforce interactive user setup, breaking headless setup. It's possible to opt out by having a userconf or userconf.txt file present (similar to ssh/ssh.txt for enabling the SSH server). This change adds support for copying this file during setup.